### PR TITLE
add cruft pattern to svg-sprite regex

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -77,7 +77,7 @@ module.exports = {
       {{/if}}
       {{#if svg}}
       {
-        test: /\.svg$/,
+        test: /\.svg(\?.*)?$/,
         loader: 'svg-sprite?' + JSON.stringify({
           name: '[name]_[hash]',
           spriteModule: 'utils/sprite',


### PR DESCRIPTION
If you opt to use svg-sprites, the pattern for catching file extensions doesn't support crufted extensions. This can be a problem if your CSS references an svg with a crufted extension (e.g. the stylesheet in element-ui).